### PR TITLE
Fix joining newline segments

### DIFF
--- a/functions/utilities.zsh
+++ b/functions/utilities.zsh
@@ -361,9 +361,9 @@ function __p9k_print_deprecation_var_warning() {
 function p9k::find_first_defined() {
   local returnName
   while [ $# -ne 0 ]; do
-    if [[ "$1" == "-n" ]]; then 
+    if [[ "$1" == "-n" ]]; then
       returnName=true
-    elif [[ ! -z "${(P)1+x}" ]]; then 
+    elif [[ ! -z "${(P)1+x}" ]]; then
       [[ -n $returnName ]] && echo "$1" || echo "${(P)1}"
       break
     fi
@@ -385,28 +385,12 @@ function p9k::find_first_defined() {
 function p9k::find_first_non_empty() {
   local returnName
   while [ $# -ne 0 ]; do
-    if [[ "$1" == "-n" ]]; then 
+    if [[ "$1" == "-n" ]]; then
       returnName=true
-    elif [[ -n "${(P)1}" ]]; then 
+    elif [[ -n "${(P)1}" ]]; then
       [[ -n $returnName ]] && echo "$1" || echo "${(P)1}"
       break
     fi
     shift
   done
-}
-
-###############################################################
-# @description
-#   Joins supplied strings with specified separator.
-# @args
-#   $1 The separator to join strings with
-#   $* List of string to join.
-# @returns
-#   A joined string.
-##
-p9k::join_by() { 
-  local separator=$1
-  shift
-  local -a arr=($@)
-  echo ${(pj:$separator:)arr}
 }

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -94,7 +94,7 @@ function __p9k_left_prompt_segment() {
   local visual_identifier
   [[ -n "${SEGMENT_ICON}" ]] && visual_identifier="$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}%f"
   [[ -n "${content}" ]] && content="${fg}${content}"
-  echo -n "$(p9k::join_by "${middle_ws}" "${visual_identifier}" "${content}")${right_ws}"
+  echo -n "${visual_identifier}${middle_ws}${content}${right_ws}"
 
   CURRENT_BG=$bg
   last_left_element_index=$current_index
@@ -160,7 +160,7 @@ function __p9k_right_prompt_segment() {
   [[ ${CURRENT_RIGHT_BG} == 'NONE' ]] || echo -n "${right_ws}" # print right whitespace of prev segment
   if [[ ${joined} == false ]] || [[ ${CURRENT_RIGHT_BG} == 'NONE' ]]; then
     if [[ "${bg}" != "${CURRENT_RIGHT_BG}" ]]; then
-      # Use the new BG color for the foreground with separator 
+      # Use the new BG color for the foreground with separator
       echo -n "%F${bg#%K}${__P9K_ICONS[RIGHT_SEGMENT_SEPARATOR]}"
     else
       # Middle segment with same color as previous segment
@@ -179,8 +179,8 @@ function __p9k_right_prompt_segment() {
   [[ ${joined} == false ]] || [[ "${CURRENT_RIGHT_BG}" == "NONE" ]] && echo -n "${left_ws}"
   # Print segment content and icon, if any
   [[ "${(L)P9K_RPROMPT_ICON_LEFT}" != "true" ]] \
-    && echo -n "$(p9k::join_by "${middle_ws}" "${content}" "${visual_identifier}")" \
-    || echo -n "$(p9k::join_by "${middle_ws}" "${visual_identifier}" "${fg}${content}")"
+    && echo -n "${content}${middle_ws}${visual_identifier}" \
+    || echo -n "${visual_identifier}${middle_ws}${fg}${content}"
 
   CURRENT_RIGHT_BG=${bg}
   last_right_element_index=${current_index}
@@ -334,7 +334,6 @@ function __p9k_build_right_prompt() {
   fi
 
   echo -n "${__P9K_DATA[LAST_WHITESPACE]}${last_symbol}"
-
 }
 
 ###############################################################

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -79,7 +79,7 @@ function __p9k_left_prompt_segment() {
     fi
   else # First segment
 
-    # Custom symbol for left side of the first segment and 
+    # Custom symbol for left side of the first segment and
     # custom white space that follows it
     local first_symbol=""
     local first_ws="$__P9K_DATA[FIRST_WHITESPACE]"

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -92,9 +92,9 @@ function __p9k_left_prompt_segment() {
 
   # Print the visual identifier and content if any
   local visual_identifier
-  [[ -n "${SEGMENT_ICON}" ]] && visual_identifier="$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}%f"
+  [[ -n "${SEGMENT_ICON}" ]] && visual_identifier="$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}%f${middle_ws}"
   [[ -n "${content}" ]] && content="${fg}${content}"
-  echo -n "${visual_identifier}${middle_ws}${content}${right_ws}"
+  echo -n "${visual_identifier}${content}${right_ws}"
 
   CURRENT_BG=$bg
   last_left_element_index=$current_index
@@ -173,14 +173,20 @@ function __p9k_right_prompt_segment() {
   echo -n "${bg}${fg}"
 
   local visual_identifier
-  [[ -n "${SEGMENT_ICON}" ]] && visual_identifier="$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}%f"
+  if [[ -n "${SEGMENT_ICON}" ]]; then
+    visual_identifier="$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}%f"
+
+    [[ "${(L)P9K_RPROMPT_ICON_LEFT}" != "true" ]] \
+      && visual_identifier="${middle_ws}${visual_identifier}" \
+      || visual_identifier="${visual_identifier}${middle_ws}"
+  fi
 
   # Print whitespace only if segment is not joined or first right segment
   [[ ${joined} == false ]] || [[ "${CURRENT_RIGHT_BG}" == "NONE" ]] && echo -n "${left_ws}"
   # Print segment content and icon, if any
   [[ "${(L)P9K_RPROMPT_ICON_LEFT}" != "true" ]] \
-    && echo -n "${content}${middle_ws}${visual_identifier}" \
-    || echo -n "${visual_identifier}${middle_ws}${fg}${content}"
+    && echo -n "${content}${visual_identifier}" \
+    || echo -n "${visual_identifier}${fg}${content}"
 
   CURRENT_RIGHT_BG=${bg}
   last_right_element_index=${current_index}

--- a/generator/default.p9k
+++ b/generator/default.p9k
@@ -92,8 +92,9 @@ function __p9k_left_prompt_segment() {
 
   # Print the visual identifier and content if any
   local visual_identifier
-  [[ -n "${SEGMENT_ICON}" ]] && visual_identifier="$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}%f${middle_ws}"
+  [[ -n "${SEGMENT_ICON}" ]] && visual_identifier="$__P9K_DATA[${STATEFUL_NAME}_VI]${SEGMENT_ICON}%f"
   [[ -n "${content}" ]] && content="${fg}${content}"
+  [[ -n "${visual_identifier}" && -n "${content}" ]] && visual_identifier="${visual_identifier}${middle_ws}"
   echo -n "${visual_identifier}${content}${right_ws}"
 
   CURRENT_BG=$bg

--- a/segments/newline.p9k
+++ b/segments/newline.p9k
@@ -23,7 +23,7 @@ prompt_newline() {
   [[ "$P9K_PROMPT_ON_NEWLINE" == true ]] \
       && newline="${newline}${__P9K_ICONS[MULTILINE_NEWLINE_PROMPT_PREFIX]}"
 
-  p9k::prepare_segment "$0" "" $1 "$2" $3 "${newline}" "false" "" "%k"
+  p9k::prepare_segment "$0" "" $1 "$2" $3 "${newline}" "[[ true ]]" "" "%k"
   # Reset color variable, so that next segment starts as first
   CURRENT_BG="NONE"
 }

--- a/segments/newline.p9k
+++ b/segments/newline.p9k
@@ -17,15 +17,13 @@
 #   This is not an actual prompt segment, it is just a workaround to allow more newlines in your prompt.
 ##
 prompt_newline() {
-  local lws newline
   [[ "$1" == "right" ]] && return
-  newline=$'\n'
-  lws=$P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS
+
+  local newline=$'\n'
   [[ "$P9K_PROMPT_ON_NEWLINE" == true ]] \
       && newline="${newline}${__P9K_ICONS[MULTILINE_NEWLINE_PROMPT_PREFIX]}"
-  P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS=
 
   p9k::prepare_segment "$0" "" $1 "$2" $3 "${newline}" "false" "" "%k"
+  # Reset color variable, so that next segment starts as first
   CURRENT_BG="NONE"
-  P9K_WHITESPACE_BETWEEN_LEFT_SEGMENTS=$lws
 }

--- a/test/functions/utilities.spec
+++ b/test/functions/utilities.spec
@@ -227,37 +227,34 @@ function testFindingFirstDefinedOrNonEmptyVariableNyName() {
 
   local result=
 
-  assertEquals "$(p9k::find_first_defined var0 var1 var2)" "" # var1 value
-  assertEquals "$(p9k::find_first_defined -n var0 var1 var2)" "var1" # var1 name
+  assertEquals "" "$(p9k::find_first_defined var0 var1 var2)" # var1 value
+  assertEquals "var1" "$(p9k::find_first_defined -n var0 var1 var2)" # var1 name
 
-  assertEquals "$(p9k::find_first_non_empty var0 var1 var2)" "some value" # var2 value
-  assertEquals "$(p9k::find_first_non_empty -n var0 var1 var2)" "var2" # var2 name
+  assertEquals "some value" "$(p9k::find_first_non_empty var0 var1 var2)" # var2 value
+  assertEquals "var2" "$(p9k::find_first_non_empty -n var0 var1 var2)" # var2 name
 
   local var0=""
-  assertEquals "$(p9k::find_first_defined var0 var1 var2)" "" # var1 value
-  assertEquals "$(p9k::find_first_defined -n var0 var1 var2)" "var0" # var1 name
+  assertEquals "" "$(p9k::find_first_defined var0 var1 var2)" # var1 value
+  assertEquals "var0" "$(p9k::find_first_defined -n var0 var1 var2)" # var1 name
   var0="other value"
-  assertEquals "$(p9k::find_first_non_empty var0 var1 var2)" "other value" # var2 value
-  assertEquals "$(p9k::find_first_non_empty -n var0 var1 var2)" "var0" # var2 name
+  assertEquals "other value" "$(p9k::find_first_non_empty var0 var1 var2)" # var2 value
+  assertEquals "var0" "$(p9k::find_first_non_empty -n var0 var1 var2)" # var2 name
 
   function internal() {
     local var0="qwe"
-    assertEquals "$(p9k::find_first_defined var0 var1 var2)" "qwe" # var1 value
-    assertEquals "$(p9k::find_first_defined -n var0 var1 var2)" "var0" # var1 name
-    assertEquals "$(p9k::find_first_non_empty var0 var1 var2)" "qwe" # var2 value
-    assertEquals "$(p9k::find_first_non_empty -n var0 var1 var2)" "var0" # var2 name
+    assertEquals "qwe" "$(p9k::find_first_defined var0 var1 var2)" # var1 value
+    assertEquals "var0" "$(p9k::find_first_defined -n var0 var1 var2)" # var1 name
+    assertEquals "qwe" "$(p9k::find_first_non_empty var0 var1 var2)" # var2 value
+    assertEquals "var0" "$(p9k::find_first_non_empty -n var0 var1 var2)" # var2 name
   }
 
   internal
-
 }
 
 function testJoiningStrings() {
-
-  assertEquals "$(p9k::join_by _ hello there)" "hello_there"
-  assertEquals "$(p9k::join_by '-' one two three)" "one-two-three"
-  assertEquals "$(p9k::join_by '-' "" two three)" "two-three"
-
+  assertEquals "hello_there" "$(p9k::join_by _ hello there)"
+  assertEquals "one-two-three" "$(p9k::join_by '-' one two three)"
+  assertEquals "two-three" "$(p9k::join_by '-' "" two three)"
 }
 
 source shunit2/shunit2

--- a/test/functions/utilities.spec
+++ b/test/functions/utilities.spec
@@ -67,7 +67,7 @@ function testGetRelevantItemDoesNotReturnNotFoundItems() {
   local callback='[[ "$item" == "d" ]] && echo "found"'
 
   local result=$(p9k::get_relevant_item "$list" "$callback")
-  assertEquals '' '' # whats this ?
+  assertEquals '' "$result"
 
   unset list
 }

--- a/test/functions/utilities.spec
+++ b/test/functions/utilities.spec
@@ -255,6 +255,7 @@ function testJoiningStrings() {
   assertEquals "hello_there" "$(p9k::join_by _ hello there)"
   assertEquals "one-two-three" "$(p9k::join_by '-' one two three)"
   assertEquals "two-three" "$(p9k::join_by '-' "" two three)"
+  assertEquals $'\n'-xx "$(p9k::join_by '-' $'\n' 'xx')"
 }
 
 source shunit2/shunit2

--- a/test/functions/utilities.spec
+++ b/test/functions/utilities.spec
@@ -251,11 +251,4 @@ function testFindingFirstDefinedOrNonEmptyVariableNyName() {
   internal
 }
 
-function testJoiningStrings() {
-  assertEquals "hello_there" "$(p9k::join_by _ hello there)"
-  assertEquals "one-two-three" "$(p9k::join_by '-' one two three)"
-  assertEquals "two-three" "$(p9k::join_by '-' "" two three)"
-  assertEquals $'\n'-xx "$(p9k::join_by '-' $'\n' 'xx')"
-}
-
 source shunit2/shunit2


### PR DESCRIPTION
Hi @n1kk !

As already mentioned in #1078 , there is a regression, when using a newline segment (two newlines for this example), and configuring `P9K_MULTILINE_NEWLINE_PROMPT_PREFIX_ICON` to an empty string. This causes the `p9k::join_by` function to fail, because it just returns an empty string. Passing newlines around is somewhat problematic in ZSH.
So the conclusion was to remove the `p9k::join_by` function entirely, as I found no way to fix this. I had to add some checks, so that the middle whitespace is shown only if there is content and a visual identifier.

Please have a look over my changes and test them. Thanks.